### PR TITLE
Fix decimal color variables

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -122,19 +122,19 @@ fn build_themes() {
                 data = data.insert(base.to_string() + "-hex-r", hex_red.as_ref());
                 let red = i32::from_str_radix(color[0..2].as_ref(), 16).unwrap();
                 data = data.insert(base.to_string() + "-rgb-r", red);
-                data = data.insert(base.to_string() + "-dec-r", red / 255);
+                data = data.insert(base.to_string() + "-dec-r", red as f64 / 255.0);
 
                 let hex_green = color[2..4].to_string();
                 data = data.insert(base.to_string() + "-hex-g", hex_green.as_ref());
                 let green = i32::from_str_radix(color[2..4].as_ref(), 16).unwrap();
                 data = data.insert(base.to_string() + "-rgb-g", green);
-                data = data.insert(base.to_string() + "-dec-g", green / 255);
+                data = data.insert(base.to_string() + "-dec-g", green as f64 / 255.0);
 
                 let hex_blue = color[4..6].to_string();
                 data = data.insert(base.to_string() + "-hex-b", hex_blue.as_ref());
                 let blue = i32::from_str_radix(color[4..6].as_ref(), 16).unwrap();
                 data = data.insert(base.to_string() + "-rgb-b", blue);
-                data = data.insert(base.to_string() + "-dec-b", blue / 255);
+                data = data.insert(base.to_string() + "-dec-b", blue as f64 / 255.0);
 
                 data = data.insert(
                     base.to_string() + "-hex-bgr",


### PR DESCRIPTION
The code for calculating the color decimal values was converting the hex values into an `i32` type and then dividing by 255. Integer division constrained the value of the template variables for decimal colors to mostly 0 and occasionally 1, instead of expressing the range of values in between. I first noticed the issue while processing the [base16-iterm2](https://github.com/martinlindhe/base16-iterm2) template, which heavily makes use of the decimal color variables introduced in v0.9.0 of the base16-builder specification.